### PR TITLE
RIF-6: Updated test steps documentation for all test cases

### DIFF
--- a/desktop_tests/test_contact_page.robot
+++ b/desktop_tests/test_contact_page.robot
@@ -7,10 +7,16 @@ Test Teardown     default_test_teardown
 Suite Teardown    default_suite_teardown
 Force Tags        desktop    offsite
 
-# PreCond: User is logged out & Clear cookies/cache
 
 *** Test Cases ***
 contact_pg_submit_form_valid_inputs_happy_path
+    [Tags]    smoke
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to Contact Page
+    ...    2. Enter valid inputs in all form fields and submit
+    ...    ER: Form submits and confirmation message is displayed
+
     # 1. Go to Contact Page
     go_to_url    ${var_contact_page_path}
 
@@ -22,10 +28,18 @@ contact_pg_submit_form_valid_inputs_happy_path
     get_element_text_and_compare_to_exp_text    ${loc_contform_conf_msg}    ${contform_conf_msg}    equals
 
 contact_pg_submit_form_verify_req_fields
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to Contact Page
+    ...    2. Leave all fields empty and submit
+    ...    ER: Form does not submit and Req field msg displays for Req fields
+    ...    3. Enter valid inputs in all form fields and submit
+    ...    ER: Form submits and confirmation message is displayed
+
     # 1. Go to Contact Page
     go_to_url    ${var_contact_page_path}
 
-    # 2. Click submit button (leave all fields empty)
+    # 2. Click submit button
     wait_then_click_button    ${loc_contform_submit_btn}
 
     # ER: Form does not submit and Req field error msg displays for applicable fields

--- a/desktop_tests/test_global_header.robot
+++ b/desktop_tests/test_global_header.robot
@@ -7,14 +7,15 @@ Test Teardown     default_test_teardown
 Suite Teardown    default_suite_teardown
 Force Tags        desktop    offsite
 
-# PreCond: User is logged out & Clear cookies/cache
 
 *** Test Cases ***
 globhdr_main_nav_click_links_verify_landing_page
     [Tags]    smoke    header    main_nav
-    # 1. Go to any page with global header (Ex. Home Page)
-    # 2. Main Nav: For each link, click the link and verify landing page (compare link text to h1 text)
-    # ER: The landing page is correct
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to any page that displays the global header (Ex. Home Page)
+    ...    2. Main Nav: For each link, click the link and verify landing page (compare link text to landing page h1 text)
+    ...    ER: The user is directed to the correct landing page
 
     loop_thru_links_verify_landing_page
     ...    ${EMPTY}

--- a/desktop_tests/test_global_sidebar.robot
+++ b/desktop_tests/test_global_sidebar.robot
@@ -7,14 +7,14 @@ Test Teardown     default_test_teardown
 Suite Teardown    default_suite_teardown
 Force Tags        desktop    offsite    sidebar
 
-# PreCond: User is logged out & Clear cookies/cache
 
 *** Test Cases ***
 globsb_lm_wgt_click_links_verify_landing_page
     [Documentation]
-    ...    # 1. Go to any page with global sidebar (ex. Home Page)
-    ...    # 2. Learn More widget: For each link, click the link and verify landing page (compare link text to h1 text)
-    ...    # ER: The landing page is correct
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to any page that displays the global sidebar (ex. Home Page)
+    ...    2. Learn More widget: For each link, click the link and verify landing page (compare link text to landing page h1 text)
+    ...    ER: The user is directed to the correct landing page
 
     loop_thru_links_verify_landing_page
     ...    ${EMPTY}
@@ -26,9 +26,10 @@ globsb_lm_wgt_click_links_verify_landing_page
 
 globsb_ra_wgt_click_links_verify_landing_page
     [Documentation]
-    ...    # 1. Go to any page with global sidebar (ex. Home Page)
-    ...    # 2. Recently Added widget: For each link, click the link and verify landing page (compare link text to h1 text)
-    ...    # ER: The landing page is correct
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to any page that displays the global sidebar (ex. Home Page)
+    ...    2. Recently Added widget: For each link, click the link and verify landing page (compare link text to landing page h1 text)
+    ...    ER: The user is directed to the correct landing page
 
     loop_thru_links_verify_landing_page
     ...    ${EMPTY}

--- a/desktop_tests/test_home_page.robot
+++ b/desktop_tests/test_home_page.robot
@@ -7,40 +7,48 @@ Suite Teardown    default_suite_teardown
 Test Teardown     default_test_teardown
 Force Tags        desktop    offsite
 
-# PreCond: User is logged out & Clear cookies/cache
 
 *** Test Cases ***
 hp_splt_widget_click_links_verify_landing_page
-    # 1. Go to the Home Page
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to the Home Page
+    ...    2. In the Robot Spotlight widget, click the link in the first feature box and verify landing page (compare link text to landing page h1 text)
+    ...    ER: The user is directed to the correct landing page
+    ...    3. Go to the Home Page
+    ...    4. In the Robot Spotlight widget, click the View All link and verify landing page (compare link text to landing page h1 text)
+    ...    ER: The user is directed to the correct landing page
 
-    # 2. In the Spotlight widget, save the Title name for the first feature box
+    # 1. Go to the Home Page (handled via Suite Setup)
+
+    # 2a. In the Spotlight widget, save the Title name for the first feature box
     ${hp_title_name}=    hp_splt_widget_feat_box_get_title_name
 
-    # 3. Click the title name link for the box
+    # 2b. Click the title name link for the box
     wait_then_click_link    ${loc_hp_splt_widget_feat_box_title_name_link}
 
-    # 4. On the landing page, save the h1 Title text
+    # 2c. On the landing page, save the h1 Title text
     ${titlepg_title_name}=    get_h1_text
 
-    # 5. Compare the h1 Title text (#4) to the Title name text (#2)
+    # 2d. Compare the h1 Title text (#4) to the Title name text (#2)
     # ER: They are the same
     Should Contain    ${titlepg_title_name}    ${hp_title_name}
 
-    # 5. Go to the Home Page
+    # 3. Go to the Home Page
     go_to_url    ${var_home_page_path}
 
-    # 6. In the Spotlight widget, save the View All link text
+    # 4a. In the Spotlight widget, save the View All link text
     ${view_all_text}=    hp_splt_widget_viewall_box_get_view_all_link_text
 
-    # 7. Click the View All link
+    # 4b. Click the View All link
     wait_then_click_link    ${loc_hp_splt_widget_viewall_box_view_all_link}
 
-    # 8. On the Tag Page, save the h1 Title text
+    # 4c. On the Tag Page, save the h1 Title text
     ${tagpg_title_name}=    get_h1_text
 
-    # 9. Extract the tag name from the h1 text string
+    # 4d. Extract the tag name from the h1 text string
     ${tagpg_tag_name}=    Get Substring    ${tagpg_title_name}    5
 
-    # 9. Compare the tag name (#9) to the View All Link text (#6)
+    # 4e. Compare the tag name (#9) to the View All Link text (#6)
     # ER: The View All text contains the tag name
     Should Contain    ${view_all_text}    ${tagpg_tag_name}

--- a/desktop_tests/test_library_page.robot
+++ b/desktop_tests/test_library_page.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation     RiF Library Page tests
+Documentation     Library Page tests
 Resource          ../resources/master.robot
 
 Suite Setup       default_suite_setup
@@ -7,13 +7,14 @@ Test Teardown     default_test_teardown
 Suite Teardown    default_suite_teardown
 Force Tags        desktop    offsite
 
-# PreCond: User is logged out & Clear cookies/cache
 
 *** Test Cases ***
 lib_pg_bycat_wgt_click_links_verify_landing_page
-    # 1. Go to RiF Library Page
-    # 2. By Category widget: For each link, click the link and verify landing page (compare link textto h1 text)
-    # ER: The landing page is correct
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to Library Page
+    ...    2. By Category widget: For each link, click the link and verify landing page (compare link text to landing page h1 text)
+    ...    ER: The user is directed to the correct landing page
 
     loop_thru_links_verify_landing_page
     ...    ${var_lib_page_path}

--- a/desktop_tests/test_login_path.robot
+++ b/desktop_tests/test_login_path.robot
@@ -7,11 +7,16 @@ Test Teardown     default_test_teardown
 Suite Teardown    default_suite_teardown
 Force Tags        desktop    login
 
-# PreCond: User is logged out
 
 *** Test Cases ***
 login_path_login_valid_creds_subscriber_happy_path
     [Tags]    smoke
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to Login Page
+    ...    2. Enter valid Subscriber un/pw and submit
+    ...    ER: User redirected to Profile Page and correct username is displayed
+
     # 1. Go to Login Page
     go_to_url    ${var_login_page_path}
 
@@ -25,10 +30,16 @@ login_path_login_valid_creds_subscriber_happy_path
     profile_page_username_field_displays_correct_user    ${test_subscriber_username}
 
 login_page_login_empty_creds
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to Login Page
+    ...    2. Leave all fields empty and submit
+    ...    ER: User remains on Login Page and un/pw fields are empty
+
     # 1. Go to Login Page
     go_to_url    ${var_login_page_path}
 
-    # 2. Leave empty un/pw and submit
+    # 2. Submit form
     lgnform_click_login_button
 
     # ER: User remains on Login Page and un/pw fields are empty
@@ -37,6 +48,12 @@ login_page_login_empty_creds
     lgnform_pw_field_displays_text   ${EMPTY}
 
 login_page_login_invalid_pw_creds
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to Login Page
+    ...    2. Enter valid un and invalid pw and submit
+    ...    ER: User remains on Login Page and invalid un/pw msg is displayed
+
     # 1. Go to Login Page
     go_to_url    ${var_login_page_path}
 

--- a/desktop_tests/test_lostpw_path.robot
+++ b/desktop_tests/test_lostpw_path.robot
@@ -7,11 +7,16 @@ Test Teardown     default_test_teardown
 Suite Teardown    default_suite_teardown
 Force Tags        desktop    lost_pw
 
-# PreCond: User is logged out & Clear cookies/cache
 
 *** Test Cases ***
 lostpw_page_submit_valid_email_happy_path
     [Tags]    smoke
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to Lost Password Page
+    ...    2. Enter valid Subscriber user email and submit
+    ...    ER: User is directed to Lost PW Confirmation Page and confirmation message is displayed
+
     # 1. Go to Lost Password Page
     go_to_url    ${var_lostpw_page_path}
 
@@ -26,10 +31,16 @@ lostpw_page_submit_valid_email_happy_path
 
 
 lostpw_page_submit_empty_email
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to Lost Password Page
+    ...    2. Leave all fields empty and submit
+    ...    ER: User remains on Lost Password Page and empty-input error message displays
+
     # 1. Go to Lost Password Page
     go_to_url    ${var_lostpw_page_path}
 
-    # 2. Submit (Email field empty)
+    # 2. Submit form
     wait_then_click_button    ${loc_lostpwform_get_new_pw_btn}
 
     # ER: User remains on Lost Password Page and error message displays
@@ -38,10 +49,16 @@ lostpw_page_submit_empty_email
 
 
 lostpw_page_submit_notfound_email
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to Lost Password Page
+    ...    2. Input not-found email (that does not exist in user table) and submit
+    ...    ER: User remains on Lost Password Page and not-found error message displays
+
     # 1. Go to Lost Password Page
     go_to_url    ${var_lostpw_page_path}
 
-    # 2. Input email that does not exist in user table and submit
+    # 2. Input not-found email and submit
     lostpwform_input_text_in_email_field    notfound@robotsinfilm.com
     wait_then_click_button    ${loc_lostpwform_get_new_pw_btn}
 

--- a/desktop_tests/test_search_path.robot
+++ b/desktop_tests/test_search_path.robot
@@ -7,12 +7,22 @@ Test Teardown     default_test_teardown
 Suite Teardown    default_suite_teardown
 Force Tags        desktop    search    offsite
 
-# PreCond: User is logged out & Clear cookies/cache
 
 *** Test Cases ***
 srch_path_globsb_submit_search_has_results_with_pag_happy_path
     [Tags]    smoke    sidebar
-    # 1. Go to Home Page
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to Home Page
+    ...    2. In the Global sidebar Search widget: Submit a search term that has paginated results (ex. star)
+    ...    ER: User is directed to the Search Results Page and h1 title text contains search term
+    ...    3. Review the Page 1 search results, scroll down and click the Next arrow button and review the Page 2 search results
+    ...    ER: There aren't any duplicate results
+    ...    4. Click the first search result on page 2
+    ...    ER: User is directed to the corresponding Title page (link text matches page's title text)
+
+    # 1. Go to Home Page (handled via Suite Setup)
+
     # 2. Sidebar Search widget: Submit a search term that has results with pagination (ex. star)
     ${srch_term}=    Set Variable    star
     srch_wgt_input_text_and_submit    ${loc_srch_wgt_text_box_globsb}    ${loc_srch_wgt_submit_btn_globsb}    ${srch_term}
@@ -21,43 +31,48 @@ srch_path_globsb_submit_search_has_results_with_pag_happy_path
     ${title_text}=    get_h1_text
     Should Contain    ${title_text}    ${srch_term}
 
-    # 3. Save all search result titles in a list
+    # 3a. Save all  page 1 search result titles in a list
     @{list_titles_elements}=    Get Webelements    ${loc_srch_rslt_h2_title_link}
     ${list_titles_text}=    Create List    # create empty list to store titles
     :FOR    ${element}    IN    @{list_titles_elements}
         \   ${text}=    Get Text    ${element}
         \   Append To List    ${list_titles_text}    ${text}
 
-    # 4. At bottom of results, click right arrow (next page) pagination button
+    # 3b. At bottom of results, click right arrow (next page) pagination button
     wait_then_click_link    ${loc_srch_rslt_pag_next_arrow}
 
-    # ER: User directed to next results page and h1 title text contains search term
+    # ER: User directed to page 2 and h1 title text contains search term
     ${title_text}=    get_h1_text
     Should Contain    ${title_text}    ${srch_term}
 
-    # ER: Add page 2 result titles to list and verify no dupes vs page 1
+    # 3c: Add page 2 result titles to list
     @{list_titles_elements}=    Get Webelements    ${loc_srch_rslt_h2_title_link}
     :FOR    ${element}    IN    @{list_titles_elements}
         \   ${text}=    Get Text    ${element}
         \   Append To List    ${list_titles_text}    ${text}
 
+    # ER: Verify no dupes on page 2 vs page 1
     List Should Not Contain Duplicates    ${list_titles_text}
 
-    # 5. Click the first search result on the current page
-    # ER: User is directed to corresponding page (link text matches page's title text)
+    # 4. Click the first search result on the current page
+    # ER: User is directed to the corresponding Title page (link text matches page's title text)
     ${link_text}=    Get Text    ${loc_srch_rslt_h2_title_link}
     wait_then_click_link    ${loc_srch_rslt_h2_title_link}
     get_element_text_and_compare_to_exp_text    ${loc_h1}    ${link_text}    equals
 
 
 srch_path_srch_rslt_pg_submit_search_no_results
-    [Tags]
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to the Search Results Page with Search widget displayed
+    ...    2. Search widget: Submit a search term that wil not return any results (ex. wxyz)
+    ...    ER: User is directed to Search Results Page and no results message displays
+
     # 1. Go to Search Results Page with Search widget displayed
     go_to_url    ${srch_rslt_page_path_displays_srch_wgt}
 
-    # 2. Search widget: Submit a search term that has results with pagination (ex. star)
-    ${srch_term}=    Set Variable    wxyz
-    srch_wgt_input_text_and_submit    ${loc_srch_wgt_text_box_srch_rslt_pg}    ${loc_srch_wgt_submit_btn_srch_rslt_pg}    ${srch_term}
+    # 2. Search widget: Submit a search term that wil not return any results
+    srch_wgt_input_text_and_submit    ${loc_srch_wgt_text_box_srch_rslt_pg}    ${loc_srch_wgt_submit_btn_srch_rslt_pg}    wxyz
 
     # ER: User directed to Search Results Page and no results message displays
     ${act_text}=    Get Text    ${loc_srch_rslt_no_result_msg_text}

--- a/desktop_tests/test_title_page.robot
+++ b/desktop_tests/test_title_page.robot
@@ -7,17 +7,20 @@ Test Teardown     default_test_teardown
 Suite Teardown    default_suite_teardown
 Force Tags        desktop    offsite
 
-# PreCond: User is logged out & Clear cookies/cache
 
 *** Test Cases ***
 title_pg_title_details_are_displayed
+    [Tags]    smoke
+    [Documentation]
+    ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
+    ...    1. Go to a Title page
+    ...    2. observe the content for each of the following elements: h1 text, title-specs, summary, and cast table headers
+    ...    ER: Verify each element has content (not empty)
+
     # 1. Go to a title page
     go_to_url    ${var_title_page_path}
 
-    # 2. Verify the following title details contain content:
-    # h1 text, title-specs, summary, and cast table headers
-
-    # Get the text from the elements, save to list and verify each has content (not empty):
+    # 2a. Get the text from each of the title details elements and save to list
     @{list_elements_text}=    Create List
 
     ${text}=    get_h1_text
@@ -29,18 +32,19 @@ title_pg_title_details_are_displayed
     ${text}=    Get Text    ${loc_title_page_summary_block}
     Append To List    ${list_elements_text}    ${text}
 
-    # Get count of children under #title-details
+    # 2b. Get count of children under #title-details
     ${child_num}=    Get Element Count    css=#title-details > *
 
-    # Set child index and get text for ROBOT CAST th locator
+    # 2c. Set child index and get text for ROBOT CAST th locator
     ${i}=    Evaluate    (${child_num} - 1)
     ${text}=    Get Text    css=#title-details > table:nth-child(${i}) th
     Append To List    ${list_elements_text}    ${text}
 
-    # Set child index and get text for NON-ROBOT CAST th locator
+    # 2d. Set child index and get text for NON-ROBOT CAST th locator
     ${i}=    Evaluate    "${child_num}"
     ${text}=    Get Text    css=#title-details > table:nth-child(${i}) th
     Append To List    ${list_elements_text}    ${text}
 
+    # ER: Verify each element in the list is not empty
     :FOR  ${item}  IN  @{list_elements_text}
         \    Should Not Be Empty    ${item}


### PR DESCRIPTION
Added [Documentation} section to the beginning of each test case and added manual test steps:

> [Documentation]
> ...    PreCond: Clean browser (cleared cookies/cache) and User is logged out
> ...    1. Go to Contact Page
> ...    2. Enter valid inputs in all form fields and submit
> ...    ER: Form submits and confirmation message is displayed

Updated each test case's script comments to reference the manual test step each supports.

> 1 Go to Contact Page
> go_to_url    ${var_contact_page_path}
> 
> 2 Enter valid inputs in all form fields and submit
> contform_input_data_and_submit    This is a test.
> 
> ER: Form submits and confirmation message is displayed
> Wait Until Page Does Not Contain Element    ${loc_contform_container}
> get_element_text_and_compare_to_exp_text    
> ...    ${loc_contform_conf_msg}    
> ...    ${contform_conf_msg}   
> ...    equals